### PR TITLE
Implement category management lifecycle across stack

### DIFF
--- a/backend/internal/domain/models.go
+++ b/backend/internal/domain/models.go
@@ -22,13 +22,17 @@ type User struct {
 }
 
 type Category struct {
-	ID        string    `json:"id"`
-	FamilyID  string    `json:"family_id"`
-	Name      string    `json:"name"`
-	Type      string    `json:"type"`
-	Color     string    `json:"color"`
-	IsSystem  bool      `json:"is_system"`
-	CreatedAt time.Time `json:"created_at"`
+	ID          string    `json:"id"`
+	FamilyID    string    `json:"family_id"`
+	ParentID    *string   `json:"parent_id,omitempty"`
+	Name        string    `json:"name"`
+	Type        string    `json:"type"`
+	Color       string    `json:"color"`
+	IsSystem    bool      `json:"is_system"`
+	Description string    `json:"description"`
+	IsArchived  bool      `json:"is_archived"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 type Transaction struct {

--- a/backend/internal/http/server.go
+++ b/backend/internal/http/server.go
@@ -37,6 +37,9 @@ func RegisterRoutes(e *echo.Echo, handlers *Handlers) {
 	api.POST("/users", handlers.RegisterUser)
 	api.GET("/users/:id", handlers.GetUser)
 	api.GET("/users/:id/categories", handlers.ListCategories)
+	api.POST("/users/:id/categories", handlers.CreateCategory)
+	api.PUT("/users/:id/categories/:categoryId", handlers.UpdateCategory)
+	api.POST("/users/:id/categories/:categoryId/archive", handlers.ToggleCategoryArchive)
 	api.POST("/transactions", handlers.CreateTransaction)
 	api.GET("/users/:id/transactions", handlers.ListTransactions)
 }

--- a/migrations/0002_categories_enhancements.sql
+++ b/migrations/0002_categories_enhancements.sql
@@ -1,0 +1,13 @@
+ALTER TABLE categories
+    ADD COLUMN parent_id UUID NULL;
+
+ALTER TABLE categories
+    ADD COLUMN description TEXT;
+
+ALTER TABLE categories
+    ADD COLUMN is_archived BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE categories
+    ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+CREATE INDEX IF NOT EXISTS idx_categories_family_active ON categories(family_id, is_archived);

--- a/mobile/ios/FamilyBudget/ContentView.swift
+++ b/mobile/ios/FamilyBudget/ContentView.swift
@@ -7,8 +7,18 @@ struct ContentView: View {
     @State private var familyName = ""
     @State private var currency = "RUB"
     @State private var status = "Создайте владельца семьи"
-    @State private var categories: [String] = []
+    @State private var user: User? = nil
+    @State private var family: Family? = nil
+    @State private var categories: [Category] = []
     @State private var isLoading = false
+    @State private var categoryName = ""
+    @State private var categoryType: CategoryType = .expense
+    @State private var categoryColor = "#0EA5E9"
+    @State private var categoryDescription = ""
+    @State private var categoryParentId: String? = nil
+    @State private var editingCategoryId: String? = nil
+    @State private var categoryMessage = ""
+    @State private var isSavingCategory = false
 
     var body: some View {
         NavigationView {
@@ -18,9 +28,7 @@ struct ContentView: View {
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                     registrationCard
-                    if !categories.isEmpty {
-                        categoryCard
-                    }
+                    categoryManagement
                 }
                 .padding()
             }
@@ -61,18 +69,20 @@ struct ContentView: View {
         .cornerRadius(16)
     }
 
-    private var categoryCard: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Базовые категории")
-                .font(.headline)
-            ForEach(categories, id: \.self) { category in
-                Text("• \(category)")
-                    .font(.subheadline)
+    private var categoryManagement: some View {
+        Group {
+            if let user = user {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(family?.name ?? "")
+                        .font(.headline)
+                    categoryForm(userId: user.id)
+                    categoryLists(userId: user.id)
+                }
+                .padding()
+                .background(.thinMaterial)
+                .cornerRadius(16)
             }
         }
-        .padding()
-        .background(.thinMaterial)
-        .cornerRadius(16)
     }
 
     private var canSubmit: Bool {
@@ -120,6 +130,8 @@ struct ContentView: View {
             }
 
             DispatchQueue.main.async {
+                user = registerResponse.user
+                family = registerResponse.family
                 status = "Профиль создан для \(registerResponse.user.name)"
             }
 
@@ -135,9 +147,258 @@ struct ContentView: View {
                 let response = try? JSONDecoder().decode(CategoryList.self, from: data)
             else { return }
             DispatchQueue.main.async {
-                categories = response.categories.map(\.name)
+                categories = response.categories.sorted { lhs, rhs in
+                    if lhs.isArchived == rhs.isArchived {
+                        return lhs.name < rhs.name
+                    }
+                    return !lhs.isArchived && rhs.isArchived
+                }
             }
         }.resume()
+    }
+
+    private func saveCategory(for userId: String) {
+        guard !categoryName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            categoryMessage = "Название категории обязательно"
+            return
+        }
+        let isEditing = editingCategoryId != nil
+        let endpoint: String
+        if let editingCategoryId {
+            endpoint = "http://localhost:8080/api/v1/users/\(userId)/categories/\(editingCategoryId)"
+        } else {
+            endpoint = "http://localhost:8080/api/v1/users/\(userId)/categories"
+        }
+        guard let url = URL(string: endpoint) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = isEditing ? "PUT" : "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let payload = CategoryPayload(
+            name: categoryName,
+            type: categoryType.rawValue,
+            color: categoryColor,
+            description: categoryDescription.isEmpty ? nil : categoryDescription,
+            parentId: categoryParentId
+        )
+
+        request.httpBody = try? JSONEncoder().encode(payload)
+        isSavingCategory = true
+        categoryMessage = ""
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            DispatchQueue.main.async {
+                isSavingCategory = false
+            }
+            if let error = error {
+                DispatchQueue.main.async {
+                    categoryMessage = "Ошибка: \(error.localizedDescription)"
+                }
+                return
+            }
+            guard
+                let data = data,
+                let response = try? JSONDecoder().decode(CategoryResponse.self, from: data)
+            else {
+                DispatchQueue.main.async {
+                    categoryMessage = "Некорректный ответ сервера"
+                }
+                return
+            }
+            DispatchQueue.main.async {
+                let category = response.category
+                categories.removeAll { $0.id == category.id }
+                categories.append(category)
+                categories.sort { lhs, rhs in
+                    if lhs.isArchived == rhs.isArchived {
+                        return lhs.name < rhs.name
+                    }
+                    return !lhs.isArchived && rhs.isArchived
+                }
+                categoryMessage = isEditing ? "Категория обновлена" : "Категория создана"
+                resetCategoryForm()
+            }
+        }.resume()
+    }
+
+    private func archiveCategory(userId: String, category: Category, archived: Bool) {
+        guard let url = URL(string: "http://localhost:8080/api/v1/users/\(userId)/categories/\(category.id)/archive") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONEncoder().encode(CategoryArchiveRequest(archived: archived))
+
+        URLSession.shared.dataTask(with: request) { data, _, error in
+            if let error = error {
+                DispatchQueue.main.async {
+                    categoryMessage = "Ошибка: \(error.localizedDescription)"
+                }
+                return
+            }
+            guard
+                let data = data,
+                let response = try? JSONDecoder().decode(CategoryResponse.self, from: data)
+            else { return }
+            DispatchQueue.main.async {
+                let category = response.category
+                categories = categories.map { $0.id == category.id ? category : $0 }
+                categories.sort { lhs, rhs in
+                    if lhs.isArchived == rhs.isArchived {
+                        return lhs.name < rhs.name
+                    }
+                    return !lhs.isArchived && rhs.isArchived
+                }
+                categoryMessage = archived ? "Категория архивирована" : "Категория восстановлена"
+                if archived && editingCategoryId == category.id {
+                    resetCategoryForm()
+                }
+            }
+        }.resume()
+    }
+
+    private func resetCategoryForm() {
+        categoryName = ""
+        categoryType = .expense
+        categoryColor = "#0EA5E9"
+        categoryDescription = ""
+        categoryParentId = nil
+        editingCategoryId = nil
+    }
+
+    @ViewBuilder
+    private func categoryForm(userId: String) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(editingCategoryId == nil ? "Новая категория" : "Редактирование категории")
+                .font(.headline)
+            TextField("Название", text: $categoryName)
+                .textFieldStyle(.roundedBorder)
+            Picker("Тип", selection: $categoryType) {
+                ForEach(CategoryType.allCases, id: \.self) { type in
+                    Text(type.localizedTitle).tag(type)
+                }
+            }
+            .pickerStyle(.segmented)
+            TextField("Цвет", text: $categoryColor)
+                .textFieldStyle(.roundedBorder)
+            TextField("Описание", text: $categoryDescription)
+                .textFieldStyle(.roundedBorder)
+            Menu("Родительская категория: \(parentName)") {
+                Button("Без родителя") {
+                    categoryParentId = nil
+                }
+                ForEach(activeCategories.filter { $0.id != editingCategoryId }) { category in
+                    Button(category.name) {
+                        categoryParentId = category.id
+                    }
+                }
+            }
+            HStack {
+                Button(action: { saveCategory(for: userId) }) {
+                    if isSavingCategory {
+                        ProgressView()
+                    }
+                    Text(editingCategoryId == nil ? "Создать" : "Сохранить")
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isSavingCategory)
+
+                if editingCategoryId != nil {
+                    Button("Отмена", action: resetCategoryForm)
+                        .buttonStyle(.bordered)
+                        .disabled(isSavingCategory)
+                }
+            }
+            if !categoryMessage.isEmpty {
+                Text(categoryMessage)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func categoryLists(userId: String) -> some View {
+        let active = activeCategories
+        let archived = archivedCategories
+        if active.isEmpty && archived.isEmpty {
+            Text("Добавьте первую категорию, чтобы фиксировать движения средств")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        if !active.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Активные")
+                    .font(.headline)
+                ForEach(active) { category in
+                    categoryRow(userId: userId, category: category, archived: false)
+                }
+            }
+        }
+        if !archived.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Архив")
+                    .font(.headline)
+                ForEach(archived) { category in
+                    categoryRow(userId: userId, category: category, archived: true)
+                }
+            }
+        }
+    }
+
+    private func categoryRow(userId: String, category: Category, archived: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(category.name)
+                    .font(.subheadline)
+                    .bold()
+                Spacer()
+                Text(category.localizedType)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            if let description = category.description, !description.isEmpty {
+                Text(description)
+                    .font(.footnote)
+            }
+            HStack {
+                if !archived {
+                    Button("Изменить") {
+                        editingCategoryId = category.id
+                        categoryName = category.name
+                        categoryType = CategoryType(rawValue: category.type) ?? .expense
+                        categoryColor = category.color
+                        categoryDescription = category.description ?? ""
+                        categoryParentId = category.parentId
+                    }
+                    .buttonStyle(.bordered)
+                }
+                if !category.isSystem {
+                    Button(archived ? "Вернуть" : "Архивировать") {
+                        archiveCategory(userId: userId, category: category, archived: !archived)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+        }
+        .padding()
+        .background(.ultraThinMaterial)
+        .cornerRadius(12)
+    }
+
+    private var activeCategories: [Category] {
+        categories.filter { !$0.isArchived }
+    }
+
+    private var archivedCategories: [Category] {
+        categories.filter { $0.isArchived }
+    }
+
+    private var parentName: String {
+        if let id = categoryParentId, let category = categories.first(where: { $0.id == id }) {
+            return category.name
+        }
+        return "Без родителя"
     }
 }
 
@@ -174,7 +435,73 @@ private struct CategoryList: Codable {
     let categories: [Category]
 }
 
-private struct Category: Codable {
+private struct Category: Codable, Identifiable {
     let id: String
+    let familyId: String
+    let parentId: String?
     let name: String
+    let type: String
+    let color: String
+    let description: String?
+    let isSystem: Bool
+    let isArchived: Bool
+    let createdAt: String
+    let updatedAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case familyId = "family_id"
+        case parentId = "parent_id"
+        case name
+        case type
+        case color
+        case description
+        case isSystem = "is_system"
+        case isArchived = "is_archived"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+
+    var localizedType: String {
+        switch type {
+        case "income": return "Доход"
+        case "transfer": return "Перевод"
+        default: return "Расход"
+        }
+    }
+}
+
+private struct CategoryPayload: Codable {
+    let name: String
+    let type: String
+    let color: String
+    let description: String?
+    let parentId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case name, type, color, description
+        case parentId = "parent_id"
+    }
+}
+
+private struct CategoryResponse: Codable {
+    let category: Category
+}
+
+private struct CategoryArchiveRequest: Codable {
+    let archived: Bool
+}
+
+private enum CategoryType: String, CaseIterable {
+    case income
+    case expense
+    case transfer
+
+    var localizedTitle: String {
+        switch self {
+        case .income: return "Доход"
+        case .expense: return "Расход"
+        case .transfer: return "Перевод"
+        }
+    }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -87,6 +87,93 @@ paths:
                       $ref: '#/components/schemas/Category'
         '404':
           description: Not found
+    post:
+      summary: Create a category in the user's family
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategoryRequest'
+      responses:
+        '201':
+          description: Created category
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryResponse'
+        '400':
+          description: Validation error
+        '404':
+          description: User not found
+  /api/v1/users/{id}/categories/{categoryId}:
+    put:
+      summary: Update a category
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: categoryId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategoryRequest'
+      responses:
+        '200':
+          description: Updated category
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryResponse'
+        '400':
+          description: Validation error
+        '404':
+          description: Not found
+  /api/v1/users/{id}/categories/{categoryId}/archive:
+    post:
+      summary: Toggle archive state for a category
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: categoryId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategoryArchiveRequest'
+      responses:
+        '200':
+          description: Updated category
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryResponse'
+        '400':
+          description: Validation error
+        '404':
+          description: Not found
   /api/v1/users/{id}/transactions:
     get:
       summary: List transactions for a user
@@ -204,18 +291,55 @@ components:
           type: string
         family_id:
           type: string
+        parent_id:
+          type: string
+          nullable: true
         name:
           type: string
         type:
           type: string
-          enum: [income, expense]
+          enum: [income, expense, transfer]
         color:
           type: string
+        description:
+          type: string
+        is_archived:
+          type: boolean
         is_system:
           type: boolean
         created_at:
           type: string
           format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    CategoryRequest:
+      type: object
+      required: [name, type, color]
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+          enum: [income, expense, transfer]
+        color:
+          type: string
+        description:
+          type: string
+        parent_id:
+          type: string
+          nullable: true
+    CategoryResponse:
+      type: object
+      properties:
+        category:
+          $ref: '#/components/schemas/Category'
+    CategoryArchiveRequest:
+      type: object
+      required: [archived]
+      properties:
+        archived:
+          type: boolean
     Transaction:
       type: object
       properties:

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,8 +1,21 @@
 'use client';
 
-import { FormEvent, useState } from 'react';
-import { Category, RegisterResponse, Transaction } from '../src/lib/api';
-import { registerUser, fetchCategories, createTransaction, fetchTransactions } from '../src/lib/api';
+import { FormEvent, useMemo, useState } from 'react';
+import {
+  Category,
+  CategoryPayload,
+  RegisterResponse,
+  Transaction
+} from '../src/lib/api';
+import {
+  registerUser,
+  fetchCategories,
+  createTransaction,
+  fetchTransactions,
+  createCategory,
+  updateCategory,
+  setCategoryArchived
+} from '../src/lib/api';
 
 type Step = 'register' | 'dashboard';
 
@@ -14,14 +27,39 @@ export default function Home() {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [createError, setCreateError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isCategorySubmitting, setIsCategorySubmitting] = useState(false);
+  const [categoryError, setCategoryError] = useState<string | null>(null);
+  const [editingCategoryId, setEditingCategoryId] = useState<string | null>(null);
+  const [categoryForm, setCategoryForm] = useState<{
+    name: string;
+    type: 'income' | 'expense' | 'transfer';
+    color: string;
+    description: string;
+    parent_id: string;
+  }>({
+    name: '',
+    type: 'expense',
+    color: '#0ea5e9',
+    description: '',
+    parent_id: ''
+  });
+
+  const activeCategories = useMemo(
+    () => categories.filter((category) => !category.is_archived),
+    [categories]
+  );
+  const archivedCategories = useMemo(
+    () => categories.filter((category) => category.is_archived),
+    [categories]
+  );
 
   async function handleRegister(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setRegisterError(null);
-    const formData = new FormData(event.currentTarget);
-    setIsSubmitting(true);
-    try {
-      const response = await registerUser({
+      setRegisterError(null);
+      const formData = new FormData(event.currentTarget);
+      setIsSubmitting(true);
+      try {
+        const response = await registerUser({
         email: String(formData.get('email') ?? ''),
         password: String(formData.get('password') ?? ''),
         name: String(formData.get('name') ?? ''),
@@ -40,7 +78,7 @@ export default function Home() {
       setRegisterError(error instanceof Error ? error.message : 'Не удалось зарегистрироваться');
     } finally {
       setIsSubmitting(false);
-    }
+      }
   }
 
   async function handleCreateTransaction(event: FormEvent<HTMLFormElement>) {
@@ -67,6 +105,86 @@ export default function Home() {
       setIsSubmitting(false);
     }
   }
+
+  function resetCategoryForm() {
+    setCategoryForm({ name: '', type: 'expense', color: '#0ea5e9', description: '', parent_id: '' });
+    setEditingCategoryId(null);
+  }
+
+  function sortCategories(list: Category[]) {
+    return [...list].sort((a, b) => {
+      if (a.is_archived !== b.is_archived) {
+        return a.is_archived ? 1 : -1;
+      }
+      return a.name.localeCompare(b.name, 'ru');
+    });
+  }
+
+  async function handleCategorySubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!userData) return;
+    setCategoryError(null);
+    setIsCategorySubmitting(true);
+    const payload: CategoryPayload = {
+      name: categoryForm.name.trim(),
+      type: categoryForm.type,
+      color: categoryForm.color,
+      description: categoryForm.description.trim(),
+      parent_id: categoryForm.parent_id ? categoryForm.parent_id : null
+    };
+
+    try {
+      let category: Category;
+      if (editingCategoryId) {
+        category = await updateCategory(userData.user.id, editingCategoryId, payload);
+      } else {
+        category = await createCategory(userData.user.id, payload);
+      }
+      setCategories((prev) => {
+        const next = editingCategoryId
+          ? prev.map((item) => (item.id === category.id ? category : item))
+          : [...prev, category];
+        return sortCategories(next);
+      });
+      resetCategoryForm();
+    } catch (error) {
+      setCategoryError(error instanceof Error ? error.message : 'Не удалось сохранить категорию');
+    } finally {
+      setIsCategorySubmitting(false);
+    }
+  }
+
+  function handleCategoryEdit(category: Category) {
+    setEditingCategoryId(category.id);
+    setCategoryForm({
+      name: category.name,
+      type: category.type,
+      color: category.color,
+      description: category.description ?? '',
+      parent_id: category.parent_id ?? ''
+    });
+  }
+
+  async function handleCategoryArchive(category: Category, archived: boolean) {
+    if (!userData) return;
+    setCategoryError(null);
+    setIsCategorySubmitting(true);
+    try {
+      const updated = await setCategoryArchived(userData.user.id, category.id, { archived });
+      setCategories((prev) => sortCategories(prev.map((item) => (item.id === updated.id ? updated : item))));
+      if (editingCategoryId === category.id && archived) {
+        resetCategoryForm();
+      }
+    } catch (error) {
+      setCategoryError(error instanceof Error ? error.message : 'Не удалось обновить статус категории');
+    } finally {
+      setIsCategorySubmitting(false);
+    }
+  }
+
+  const availableParents = useMemo(() => {
+    return activeCategories.filter((category) => category.id !== editingCategoryId);
+  }, [activeCategories, editingCategoryId]);
 
   if (step === 'register') {
     return (
@@ -127,10 +245,96 @@ export default function Home() {
             <div style={{ fontSize: '0.75rem' }}>{userData?.user.email}</div>
           </div>
         </div>
-        <p className="highlight">Базовые категории: {categories.map((category) => category.name).join(', ')}</p>
+        <p className="highlight">
+          Активные статьи бюджета: {activeCategories.map((category) => category.name).join(', ') || 'добавьте первую категорию'}
+        </p>
       </section>
 
       <div className="dashboard-columns">
+        <article className="panel">
+          <h2>{editingCategoryId ? 'Редактирование категории' : 'Новая категория'}</h2>
+          <form onSubmit={handleCategorySubmit} className="form-grid">
+            <div className="input-group">
+              <label htmlFor="category_name">Название статьи</label>
+              <input
+                id="category_name"
+                name="category_name"
+                className="input"
+                value={categoryForm.name}
+                onChange={(event) => setCategoryForm((prev) => ({ ...prev, name: event.target.value }))}
+                required
+              />
+            </div>
+            <div className="input-group">
+              <label htmlFor="category_type">Тип движения</label>
+              <select
+                id="category_type"
+                name="category_type"
+                className="select"
+                value={categoryForm.type}
+                onChange={(event) =>
+                  setCategoryForm((prev) => ({ ...prev, type: event.target.value as CategoryPayload['type'] }))
+                }
+              >
+                <option value="expense">Расход</option>
+                <option value="income">Доход</option>
+                <option value="transfer">Перевод</option>
+              </select>
+            </div>
+            <div className="input-group">
+              <label htmlFor="category_color">Цвет</label>
+              <input
+                id="category_color"
+                name="category_color"
+                className="input"
+                value={categoryForm.color}
+                onChange={(event) => setCategoryForm((prev) => ({ ...prev, color: event.target.value }))}
+                placeholder="#0ea5e9"
+              />
+            </div>
+            <div className="input-group">
+              <label htmlFor="category_parent">Родительская статья</label>
+              <select
+                id="category_parent"
+                name="category_parent"
+                className="select"
+                value={categoryForm.parent_id}
+                onChange={(event) => setCategoryForm((prev) => ({ ...prev, parent_id: event.target.value }))}
+              >
+                <option value="">Без родителя</option>
+                {availableParents.map((category) => (
+                  <option key={category.id} value={category.id}>
+                    {category.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="input-group" style={{ gridColumn: '1 / -1' }}>
+              <label htmlFor="category_description">Описание статьи</label>
+              <textarea
+                id="category_description"
+                name="category_description"
+                className="textarea"
+                rows={3}
+                value={categoryForm.description}
+                onChange={(event) => setCategoryForm((prev) => ({ ...prev, description: event.target.value }))}
+                placeholder="Например: регулярные траты на обучение или спортивные секции"
+              />
+            </div>
+            {categoryError && <p className="error">{categoryError}</p>}
+            <div style={{ display: 'flex', gap: '0.75rem' }}>
+              <button type="submit" className="button" disabled={isCategorySubmitting}>
+                {isCategorySubmitting ? 'Сохранение...' : editingCategoryId ? 'Сохранить изменения' : 'Создать категорию'}
+              </button>
+              {editingCategoryId && (
+                <button type="button" className="button" onClick={resetCategoryForm} disabled={isCategorySubmitting}>
+                  Отмена
+                </button>
+              )}
+            </div>
+          </form>
+        </article>
+
         <article className="panel">
           <h2>Новая операция</h2>
           <form onSubmit={handleCreateTransaction} className="form-grid">
@@ -144,7 +348,7 @@ export default function Home() {
             <div className="input-group">
               <label htmlFor="category_id">Категория</label>
               <select id="category_id" name="category_id" className="select">
-                {categories.map((category) => (
+                {activeCategories.map((category) => (
                   <option key={category.id} value={category.id}>
                     {category.name}
                   </option>
@@ -196,6 +400,66 @@ export default function Home() {
           </ul>
         </article>
       </div>
+
+      <section className="panel">
+        <h2>Справочник категорий</h2>
+        {categories.length === 0 && <p className="highlight">Добавьте первую статью движения средств для семьи.</p>}
+        {activeCategories.length > 0 && (
+          <div style={{ marginBottom: '1.5rem' }}>
+            <h3 style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>Активные</h3>
+            <ul className="transactions">
+              {activeCategories.map((category) => (
+                <li key={category.id} className="transaction-item" style={{ alignItems: 'flex-start' }}>
+                  <div>
+                    <p style={{ fontWeight: 600, color: category.color }}>{category.name}</p>
+                    <p className="meta">Тип: {category.type === 'income' ? 'Доход' : category.type === 'expense' ? 'Расход' : 'Перевод'}</p>
+                    {category.description && <p className="highlight">{category.description}</p>}
+                  </div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                    <button className="button" onClick={() => handleCategoryEdit(category)} disabled={isCategorySubmitting}>
+                      Изменить
+                    </button>
+                    {!category.is_system && (
+                      <button
+                        className="button"
+                        onClick={() => handleCategoryArchive(category, true)}
+                        disabled={isCategorySubmitting}
+                      >
+                        Архивировать
+                      </button>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {archivedCategories.length > 0 && (
+          <div>
+            <h3 style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>Архив</h3>
+            <ul className="transactions">
+              {archivedCategories.map((category) => (
+                <li key={category.id} className="transaction-item" style={{ alignItems: 'flex-start' }}>
+                  <div>
+                    <p style={{ fontWeight: 600, color: '#94a3b8' }}>{category.name}</p>
+                    <p className="meta">Тип: {category.type === 'income' ? 'Доход' : category.type === 'expense' ? 'Расход' : 'Перевод'}</p>
+                    {category.description && <p className="highlight">{category.description}</p>}
+                  </div>
+                  <div>
+                    <button
+                      className="button"
+                      onClick={() => handleCategoryArchive(category, false)}
+                      disabled={isCategorySubmitting}
+                    >
+                      Вернуть в работу
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </section>
     </main>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -28,11 +28,28 @@ export interface Family {
 
 export interface Category {
   id: string;
+  family_id: string;
+  parent_id?: string | null;
   name: string;
-  type: 'income' | 'expense';
+  type: 'income' | 'expense' | 'transfer';
   color: string;
+  description?: string;
   is_system: boolean;
+  is_archived: boolean;
   created_at: string;
+  updated_at: string;
+}
+
+export interface CategoryPayload {
+  name: string;
+  type: 'income' | 'expense' | 'transfer';
+  color: string;
+  description?: string;
+  parent_id?: string | null;
+}
+
+export interface CategoryArchivePayload {
+  archived: boolean;
 }
 
 export interface Transaction {
@@ -94,6 +111,34 @@ export async function registerUser(payload: RegisterRequest): Promise<RegisterRe
 export async function fetchCategories(userId: string): Promise<Category[]> {
   const data = await request<{ categories: Category[] }>(`/api/v1/users/${userId}/categories`);
   return data.categories;
+}
+
+export async function createCategory(userId: string, payload: CategoryPayload): Promise<Category> {
+  const data = await request<{ category: Category }>(`/api/v1/users/${userId}/categories`, {
+    method: 'POST',
+    body: JSON.stringify(payload)
+  });
+  return data.category;
+}
+
+export async function updateCategory(userId: string, categoryId: string, payload: CategoryPayload): Promise<Category> {
+  const data = await request<{ category: Category }>(`/api/v1/users/${userId}/categories/${categoryId}`, {
+    method: 'PUT',
+    body: JSON.stringify(payload)
+  });
+  return data.category;
+}
+
+export async function setCategoryArchived(
+  userId: string,
+  categoryId: string,
+  payload: CategoryArchivePayload
+): Promise<Category> {
+  const data = await request<{ category: Category }>(`/api/v1/users/${userId}/categories/${categoryId}/archive`, {
+    method: 'POST',
+    body: JSON.stringify(payload)
+  });
+  return data.category;
 }
 
 export async function createTransaction(payload: TransactionRequest): Promise<Transaction> {


### PR DESCRIPTION
## Summary
- extend the backend category schema with description, parent, and archive support plus CRUD APIs
- publish the new capabilities through the OpenAPI spec and refreshed default seed data
- add creation, editing, and archiving flows for categories in the web app, Android client, and iOS client

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_69094455175c8320b6328378558aad13