### PR TITLE
Add transaction period filtering and unified comment support

### DIFF
--- a/backend/internal/domain/models.go
+++ b/backend/internal/domain/models.go
@@ -43,7 +43,7 @@ type Transaction struct {
 	Type        string    `json:"type"`
 	AmountMinor int64     `json:"amount_minor"`
 	Currency    string    `json:"currency"`
-	Description string    `json:"description"`
+	Comment     string    `json:"comment,omitempty"`
 	OccurredAt  time.Time `json:"occurred_at"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`

--- a/migrations/0003_transactions_comment_and_period.sql
+++ b/migrations/0003_transactions_comment_and_period.sql
@@ -1,0 +1,4 @@
+ALTER TABLE transactions
+    RENAME COLUMN description TO comment;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_user_period ON transactions(user_id, occurred_at DESC);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -183,6 +183,20 @@ paths:
           required: true
           schema:
             type: string
+        - name: start_date
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: RFC3339 timestamp inclusive lower bound
+        - name: end_date
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: RFC3339 timestamp inclusive upper bound
       responses:
         '200':
           description: Transactions
@@ -358,8 +372,9 @@ components:
           type: integer
         currency:
           type: string
-        description:
+        comment:
           type: string
+          nullable: true
         occurred_at:
           type: string
           format: date-time
@@ -384,8 +399,9 @@ components:
           type: integer
         currency:
           type: string
-        description:
+        comment:
           type: string
+          nullable: true
         occurred_at:
           type: string
           format: date-time

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -60,7 +60,7 @@ export interface Transaction {
   type: 'income' | 'expense';
   amount_minor: number;
   currency: string;
-  description?: string;
+  comment?: string;
   occurred_at: string;
   created_at: string;
   updated_at: string;
@@ -78,8 +78,13 @@ export interface TransactionRequest {
   type: 'income' | 'expense';
   amount_minor: number;
   currency: string;
-  description?: string;
+  comment?: string;
   occurred_at: string;
+}
+
+export interface TransactionFilters {
+  start_date?: string;
+  end_date?: string;
 }
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:8080';
@@ -149,7 +154,16 @@ export async function createTransaction(payload: TransactionRequest): Promise<Tr
   return data.transaction;
 }
 
-export async function fetchTransactions(userId: string): Promise<Transaction[]> {
-  const data = await request<{ transactions: Transaction[] }>(`/api/v1/users/${userId}/transactions`);
+export async function fetchTransactions(userId: string, filters?: TransactionFilters): Promise<Transaction[]> {
+  const search = new URLSearchParams();
+  if (filters?.start_date) {
+    search.set('start_date', filters.start_date);
+  }
+  if (filters?.end_date) {
+    search.set('end_date', filters.end_date);
+  }
+  const query = search.toString();
+  const url = `/api/v1/users/${userId}/transactions${query ? `?${query}` : ''}`;
+  const data = await request<{ transactions: Transaction[] }>(url);
   return data.transactions;
 }


### PR DESCRIPTION
## Summary
- add optional transaction comment storage and date range filtering in the backend API and OpenAPI spec
- expose transaction creation and period filtering in the web dashboard with consistent comment handling
- implement transaction management UI on iOS and migrate the database schema to the new comment field

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_6909a5db9bf48320a852b004699c4a34