### PR TITLE
Add period reports across backend and clients

### DIFF
--- a/backend/internal/domain/models.go
+++ b/backend/internal/domain/models.go
@@ -98,3 +98,43 @@ type PlannedOperationWithCreator struct {
 	PlannedOperation
 	Creator FamilyMember `json:"creator"`
 }
+
+type ReportPeriod struct {
+	Start *time.Time `json:"start_date,omitempty"`
+	End   *time.Time `json:"end_date,omitempty"`
+}
+
+type CurrencyAmount struct {
+	Currency    string `json:"currency"`
+	AmountMinor int64  `json:"amount_minor"`
+}
+
+type CategoryReportItem struct {
+	CategoryID    string `json:"category_id"`
+	CategoryName  string `json:"category_name"`
+	CategoryColor string `json:"category_color"`
+	Currency      string `json:"currency"`
+	AmountMinor   int64  `json:"amount_minor"`
+}
+
+type MovementReport struct {
+	Totals     []CurrencyAmount     `json:"totals"`
+	ByCategory []CategoryReportItem `json:"by_category"`
+}
+
+type AccountBalanceReport struct {
+	AccountID    string `json:"account_id"`
+	AccountName  string `json:"account_name"`
+	AccountType  string `json:"account_type"`
+	Currency     string `json:"currency"`
+	BalanceMinor int64  `json:"balance_minor"`
+	IsShared     bool   `json:"is_shared"`
+	IsArchived   bool   `json:"is_archived"`
+}
+
+type ReportsOverview struct {
+	Period          ReportPeriod           `json:"period"`
+	Expenses        MovementReport         `json:"expenses"`
+	Incomes         MovementReport         `json:"incomes"`
+	AccountBalances []AccountBalanceReport `json:"account_balances"`
+}

--- a/backend/internal/http/server.go
+++ b/backend/internal/http/server.go
@@ -45,6 +45,7 @@ func RegisterRoutes(e *echo.Echo, handlers *Handlers) {
 	api.GET("/users/:id/members", handlers.ListMembers)
 	api.POST("/transactions", handlers.CreateTransaction)
 	api.GET("/users/:id/transactions", handlers.ListTransactions)
+	api.GET("/users/:id/reports/overview", handlers.GetReportsOverview)
 	api.GET("/users/:id/planned-operations", handlers.ListPlannedOperations)
 	api.POST("/users/:id/planned-operations", handlers.CreatePlannedOperation)
 	api.POST("/users/:id/planned-operations/:operationId/complete", handlers.CompletePlannedOperation)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -278,6 +278,38 @@ paths:
                       $ref: '#/components/schemas/Transaction'
         '404':
           description: Not found
+  /api/v1/users/{id}/reports/overview:
+    get:
+      summary: Get aggregated spending, income and account balances for a family
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: start_date
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: RFC3339 timestamp inclusive lower bound
+        - name: end_date
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: RFC3339 timestamp inclusive upper bound
+      responses:
+        '200':
+          description: Aggregated report for the selected period
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportsOverviewResponse'
+        '404':
+          description: Not found
   /api/v1/users/{id}/planned-operations:
     get:
       summary: List planned operations for a user
@@ -698,3 +730,89 @@ components:
           $ref: '#/components/schemas/PlannedOperation'
         transaction:
           $ref: '#/components/schemas/Transaction'
+    ReportsOverviewResponse:
+      type: object
+      properties:
+        reports:
+          $ref: '#/components/schemas/ReportsOverview'
+    ReportsOverview:
+      type: object
+      properties:
+        period:
+          $ref: '#/components/schemas/ReportPeriod'
+        expenses:
+          $ref: '#/components/schemas/MovementReport'
+        incomes:
+          $ref: '#/components/schemas/MovementReport'
+        account_balances:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccountBalanceReport'
+      required: [period, expenses, incomes, account_balances]
+    ReportPeriod:
+      type: object
+      properties:
+        start_date:
+          type: string
+          format: date-time
+          nullable: true
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+    MovementReport:
+      type: object
+      properties:
+        totals:
+          type: array
+          items:
+            $ref: '#/components/schemas/CurrencyAmount'
+        by_category:
+          type: array
+          items:
+            $ref: '#/components/schemas/CategoryReportItem'
+      required: [totals, by_category]
+    CurrencyAmount:
+      type: object
+      properties:
+        currency:
+          type: string
+        amount_minor:
+          type: integer
+          format: int64
+      required: [currency, amount_minor]
+    CategoryReportItem:
+      type: object
+      properties:
+        category_id:
+          type: string
+        category_name:
+          type: string
+        category_color:
+          type: string
+        currency:
+          type: string
+        amount_minor:
+          type: integer
+          format: int64
+      required: [category_id, category_name, category_color, currency, amount_minor]
+    AccountBalanceReport:
+      type: object
+      properties:
+        account_id:
+          type: string
+        account_name:
+          type: string
+        account_type:
+          type: string
+          enum: [cash, card, bank, deposit, wallet]
+        currency:
+          type: string
+        balance_minor:
+          type: integer
+          format: int64
+        is_shared:
+          type: boolean
+        is_archived:
+          type: boolean
+      required: [account_id, account_name, account_type, currency, balance_minor, is_shared, is_archived]

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -141,6 +141,44 @@ export interface CompletePlannedOperationResponse {
   transaction: Transaction;
 }
 
+export interface CurrencyAmount {
+  currency: string;
+  amount_minor: number;
+}
+
+export interface CategoryReportItem {
+  category_id: string;
+  category_name: string;
+  category_color: string;
+  currency: string;
+  amount_minor: number;
+}
+
+export interface MovementReport {
+  totals: CurrencyAmount[];
+  by_category: CategoryReportItem[];
+}
+
+export interface AccountBalanceReport {
+  account_id: string;
+  account_name: string;
+  account_type: Account['type'];
+  currency: string;
+  balance_minor: number;
+  is_shared: boolean;
+  is_archived: boolean;
+}
+
+export interface ReportsOverview {
+  period: {
+    start_date?: string;
+    end_date?: string;
+  };
+  expenses: MovementReport;
+  incomes: MovementReport;
+  account_balances: AccountBalanceReport[];
+}
+
 export interface RegisterResponse {
   user: User;
   family: Family;
@@ -174,6 +212,12 @@ export interface TransactionFilters {
   type?: 'income' | 'expense';
   category_id?: string;
   account_id?: string;
+  user_id?: string;
+}
+
+export interface ReportFilters {
+  start_date?: string;
+  end_date?: string;
 }
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:8080';
@@ -277,6 +321,23 @@ export async function fetchTransactions(userId: string, filters?: TransactionFil
   const url = `/api/v1/users/${userId}/transactions${query ? `?${query}` : ''}`;
   const data = await request<{ transactions: Transaction[] }>(url);
   return data.transactions;
+}
+
+export async function fetchReportsOverview(
+  userId: string,
+  filters?: ReportFilters
+): Promise<ReportsOverview> {
+  const search = new URLSearchParams();
+  if (filters?.start_date) {
+    search.set('start_date', filters.start_date);
+  }
+  if (filters?.end_date) {
+    search.set('end_date', filters.end_date);
+  }
+  const query = search.toString();
+  const url = `/api/v1/users/${userId}/reports/overview${query ? `?${query}` : ''}`;
+  const data = await request<{ reports: ReportsOverview }>(url);
+  return data.reports;
 }
 
 export async function fetchFamilyMembers(userId: string): Promise<FamilyMember[]> {


### PR DESCRIPTION
## Summary
- add reporting domain models, aggregates, and HTTP handler to surface per-period spending, income, and balances
- expose the reports endpoint in the OpenAPI spec and consume it from the web, Android, and iOS apps with new UI sections
- ensure clients refresh reports alongside account-changing actions and display totals and breakdowns per the product wording

## Testing
- go test ./... *(hangs locally, aborted)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a9ef61d48320921ccd4cc40b4a98)