### PR TITLE
Finish mobile settings integration

### DIFF
--- a/backend/internal/domain/models.go
+++ b/backend/internal/domain/models.go
@@ -17,15 +17,32 @@ type FamilyMember struct {
 }
 
 type User struct {
-	ID              string    `json:"id"`
-	FamilyID        string    `json:"family_id"`
-	Email           string    `json:"email"`
-	Name            string    `json:"name"`
-	Role            string    `json:"role"`
-	Locale          string    `json:"locale"`
-	CurrencyDefault string    `json:"currency_default"`
-	CreatedAt       time.Time `json:"created_at"`
-	UpdatedAt       time.Time `json:"updated_at"`
+	ID              string          `json:"id"`
+	FamilyID        string          `json:"family_id"`
+	Email           string          `json:"email"`
+	Name            string          `json:"name"`
+	Role            string          `json:"role"`
+	Locale          string          `json:"locale"`
+	CurrencyDefault string          `json:"currency_default"`
+	DisplaySettings DisplaySettings `json:"display_settings"`
+	CreatedAt       time.Time       `json:"created_at"`
+	UpdatedAt       time.Time       `json:"updated_at"`
+}
+
+type DisplaySettings struct {
+	Theme                      string `json:"theme"`
+	Density                    string `json:"density"`
+	ShowArchived               bool   `json:"show_archived"`
+	ShowTotalsInFamilyCurrency bool   `json:"show_totals_in_family_currency"`
+}
+
+func DefaultDisplaySettings() DisplaySettings {
+	return DisplaySettings{
+		Theme:                      "system",
+		Density:                    "comfortable",
+		ShowArchived:               false,
+		ShowTotalsInFamilyCurrency: true,
+	}
 }
 
 type Account struct {

--- a/backend/internal/http/server.go
+++ b/backend/internal/http/server.go
@@ -36,6 +36,8 @@ func RegisterRoutes(e *echo.Echo, handlers *Handlers) {
 	api := e.Group("/api/v1")
 	api.POST("/users", handlers.RegisterUser)
 	api.GET("/users/:id", handlers.GetUser)
+	api.GET("/users/:id/settings", handlers.GetUserSettings)
+	api.PUT("/users/:id/settings", handlers.UpdateUserSettings)
 	api.GET("/users/:id/categories", handlers.ListCategories)
 	api.POST("/users/:id/categories", handlers.CreateCategory)
 	api.PUT("/users/:id/categories/:categoryId", handlers.UpdateCategory)

--- a/backend/internal/store/sqlite.go
+++ b/backend/internal/store/sqlite.go
@@ -35,6 +35,7 @@ func migrate(db *sql.DB) error {
             role TEXT NOT NULL,
             locale TEXT NOT NULL,
             currency_default TEXT NOT NULL,
+            display_settings TEXT NOT NULL,
             created_at TIMESTAMP NOT NULL,
             updated_at TIMESTAMP NOT NULL
         );`,
@@ -97,6 +98,7 @@ func migrate(db *sql.DB) error {
 		`ALTER TABLE transactions ADD COLUMN account_id TEXT REFERENCES accounts(id);`,
 		`ALTER TABLE transactions ADD COLUMN comment TEXT;`,
 		`ALTER TABLE accounts ADD COLUMN is_shared INTEGER NOT NULL DEFAULT 1;`,
+		`ALTER TABLE users ADD COLUMN display_settings TEXT NOT NULL DEFAULT '{"theme":"system","density":"comfortable","show_archived":false,"show_totals_in_family_currency":true}';`,
 	}
 
 	for _, stmt := range alterStatements {

--- a/migrations/0007_user_display_settings.sql
+++ b/migrations/0007_user_display_settings.sql
@@ -1,0 +1,18 @@
+-- Добавляем хранение пользовательских настроек отображения
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS display_settings JSONB NOT NULL DEFAULT jsonb_build_object(
+        'theme', 'system',
+        'density', 'comfortable',
+        'show_archived', false,
+        'show_totals_in_family_currency', true
+    );
+
+-- Обновляем существующие записи, у которых настройки ещё пустые
+UPDATE users
+SET display_settings = jsonb_build_object(
+        'theme', 'system',
+        'density', 'comfortable',
+        'show_archived', false,
+        'show_totals_in_family_currency', true
+    )
+WHERE display_settings = '{}'::jsonb;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -64,6 +64,51 @@ paths:
                     $ref: '#/components/schemas/Family'
         '404':
           description: Not found
+  /api/v1/users/{id}/settings:
+    get:
+      summary: Получить настройки пользователя и семьи
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Настройки пользователя
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserSettingsResponse'
+        '404':
+          description: Not found
+    put:
+      summary: Обновить настройки пользователя и семьи
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserSettingsRequest'
+      responses:
+        '200':
+          description: Обновлённые настройки
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserSettingsResponse'
+        '400':
+          description: Validation error
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
   /api/v1/users/{id}/categories:
     get:
       summary: List categories for user family
@@ -457,12 +502,79 @@ components:
           type: string
         currency_default:
           type: string
+        display_settings:
+          $ref: '#/components/schemas/DisplaySettings'
         created_at:
           type: string
           format: date-time
         updated_at:
           type: string
           format: date-time
+    DisplaySettings:
+      type: object
+      required: [theme, density, show_archived, show_totals_in_family_currency]
+      properties:
+        theme:
+          type: string
+          enum: [system, light, dark]
+        density:
+          type: string
+          enum: [comfortable, compact]
+        show_archived:
+          type: boolean
+        show_totals_in_family_currency:
+          type: boolean
+    FamilySettings:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        currency_base:
+          type: string
+    UserSettings:
+      type: object
+      properties:
+        id:
+          type: string
+        locale:
+          type: string
+        currency_default:
+          type: string
+        display:
+          $ref: '#/components/schemas/DisplaySettings'
+    UserSettingsResponse:
+      type: object
+      properties:
+        supported_currencies:
+          type: array
+          items:
+            type: string
+        family:
+          $ref: '#/components/schemas/FamilySettings'
+        user:
+          $ref: '#/components/schemas/UserSettings'
+        categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/Category'
+        accounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/Account'
+    UpdateUserSettingsRequest:
+      type: object
+      required: [user_currency, locale, display]
+      properties:
+        family_currency:
+          type: string
+        user_currency:
+          type: string
+        locale:
+          type: string
+        display:
+          $ref: '#/components/schemas/DisplaySettings'
     Family:
       type: object
       properties:

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -16,8 +16,16 @@ export interface User {
   role: string;
   locale: string;
   currency_default: string;
+  display_settings: DisplaySettings;
   created_at: string;
   updated_at: string;
+}
+
+export interface DisplaySettings {
+  theme: 'system' | 'light' | 'dark';
+  density: 'comfortable' | 'compact';
+  show_archived: boolean;
+  show_totals_in_family_currency: boolean;
 }
 
 export interface Family {
@@ -177,6 +185,30 @@ export interface ReportsOverview {
   expenses: MovementReport;
   incomes: MovementReport;
   account_balances: AccountBalanceReport[];
+}
+
+export interface UserSettingsSummary {
+  supported_currencies: string[];
+  family: {
+    id: string;
+    name: string;
+    currency_base: string;
+  };
+  user: {
+    id: string;
+    locale: string;
+    currency_default: string;
+    display: DisplaySettings;
+  };
+  categories: Category[];
+  accounts: Account[];
+}
+
+export interface UpdateUserSettingsPayload {
+  family_currency?: string;
+  user_currency: string;
+  locale: string;
+  display: DisplaySettings;
 }
 
 export interface RegisterResponse {
@@ -358,6 +390,20 @@ export async function createPlannedOperation(
     body: JSON.stringify(payload)
   });
   return data.planned_operation;
+}
+
+export async function fetchUserSettings(userId: string): Promise<UserSettingsSummary> {
+  return request<UserSettingsSummary>(`/api/v1/users/${userId}/settings`);
+}
+
+export async function updateUserSettings(
+  userId: string,
+  payload: UpdateUserSettingsPayload
+): Promise<UserSettingsSummary> {
+  return request<UserSettingsSummary>(`/api/v1/users/${userId}/settings`, {
+    method: 'PUT',
+    body: JSON.stringify(payload)
+  });
 }
 
 export async function completePlannedOperation(


### PR DESCRIPTION
## Summary
- add API, persistence, and schema changes to support display settings and shared reference data management
- extend the web dashboard with a settings surface that honours archived filters and totals preferences
- complete Android and iOS settings pages, wiring state updates, currency presets, and archived filtering across the clients

## Testing
- `./gradlew assembleDebug` *(fails: Gradle wrapper is not available in the repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b15ace2c8320b94236458a44bcf5)